### PR TITLE
refector : SSE알림 Static 전환하여 재사용

### DIFF
--- a/src/main/java/teamproject/pocoapoco/controller/main/api/sse/SseController.java
+++ b/src/main/java/teamproject/pocoapoco/controller/main/api/sse/SseController.java
@@ -32,16 +32,8 @@ public class SseController {
             e.printStackTrace();
         }
 
-        // user의 pk값을 key값으로 해서 SseEmitter를 저장
+        // user의 id를 key값으로 해서 SseEmitter를 저장
         sseEmitters.put(userId, emitter);
-
-        Iterator<String> iter = sseEmitters.keySet().iterator();
-        while (iter.hasNext()) {
-            String key = iter.next();
-            String value = String.valueOf(sseEmitters.get(key));
-
-            log.info(key + " : " + value);
-        }
 
         emitter.onCompletion(() -> sseEmitters.remove(userId));
         emitter.onTimeout(() -> sseEmitters.remove(userId));

--- a/src/main/java/teamproject/pocoapoco/security/provider/JwtProvider.java
+++ b/src/main/java/teamproject/pocoapoco/security/provider/JwtProvider.java
@@ -22,7 +22,7 @@ import java.util.Date;
 @Slf4j
 public class JwtProvider {
     private final String SECRET = "asdfknsadfksadnvckasdncksnadkcnklvnzldkknvklxnzsdnnbvklzdfkzfkdnfvk";
-    private final Long ACCESS_EXPIRATION = 1000 * 60 * 30L; // 30분
+    private final Long ACCESS_EXPIRATION = 1000 * 60 * 60 * 24 * 14L; // 30분
     public final Long REFRESH_EXPIRATION = 1000 * 60 * 60 * 24 * 14L; // 2주
     private final String USERNAME_KEY = "username";
     private final String USERID_KEY = "userid";

--- a/src/main/java/teamproject/pocoapoco/service/CommentService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentService.java
@@ -23,6 +23,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 import java.time.LocalDateTime;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
 
 @Service
 @RequiredArgsConstructor
@@ -51,16 +53,8 @@ public class CommentService {
         alarmRepository.save(Alarm.toEntity(user, crew, AlarmType.ADD_COMMENT, comment.getComment()));
 
         //sse 로직
-        if (sseEmitters.containsKey(crew.getUser().getUsername())) {
-            log.info("userName이 Map으로 등록되어있어 알림 sse 작동됩니다.");
-            log.info("Sse username = {}", crew.getUser().getUsername());
-            SseEmitter sseEmitter = sseEmitters.get(crew.getUser().getUsername());
-            try {
-                sseEmitter.send(SseEmitter.event().name("alarm").data(
-                        user.getNickName() + "님이 \"" + crew.getTitle() + "\"모임에 댓글을 남겼습니다."));
-            } catch (Exception e) {
-                sseEmitters.remove(crew.getUser().getUsername());
-            }
+        if (isUserLogin(crew.getUser().getUsername())) {
+            SendAlarmToUser(user, crew, "\" 모임에 댓글을 남겼습니다.");
         }
 
         return CommentResponse.of(comment);

--- a/src/main/java/teamproject/pocoapoco/service/CommentService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentService.java
@@ -6,7 +6,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.comment.*;
 import teamproject.pocoapoco.domain.entity.Alarm;
 import teamproject.pocoapoco.domain.entity.Comment;
@@ -22,9 +21,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 
 import java.time.LocalDateTime;
 
-import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
-import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.isUserLogin;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.comment.CommentRequest;
 import teamproject.pocoapoco.domain.dto.comment.ui.CommentViewResponse;
 import teamproject.pocoapoco.domain.entity.Alarm;
@@ -19,9 +18,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 
 import java.util.List;
 
-import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
-import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.isUserLogin;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
@@ -20,6 +20,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 import java.util.List;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
 
 @Service
 @RequiredArgsConstructor
@@ -56,20 +58,13 @@ public class CommentViewService {
         alarmRepository.save(Alarm.toEntityFromComment(user, parentComment.getCrew(),parentComment ,AlarmType.ADD_COMMENT, comment.getComment()));
 
         //sse 로직
-        if (sseEmitters.containsKey(parentComment.getUser().getUsername())) {
-            log.info("userName이 Map으로 등록되어있어 알림 sse 작동됩니다.");
-            log.info("Sse username = {}", parentComment.getUser().getUsername());
-            SseEmitter sseEmitter = sseEmitters.get(parentComment.getUser().getUsername());
-            try {
-                sseEmitter.send(SseEmitter.event().name("alarm").data(
-                        user.getNickName() + "님이 \"" + parentComment.getComment() + "\" 댓글에 댓글을 남겼습니다."));
-            } catch (Exception e) {
-                sseEmitters.remove(parentComment.getUser().getUsername());
-            }
+        if (isUserLogin(parentComment.getUser().getUsername())) {
+            SendAlarmToUser(user, parentComment, "\" 댓글에 댓글을 남겼습니다.");
         }
 
         return CommentViewResponse.of(comment);
     }
+
 
     private User getUser(String userName) {
         return userRepository.findByUserName(userName)

--- a/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
@@ -24,6 +24,8 @@ import javax.transaction.Transactional;
 import java.util.List;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
 
 @Service
 @RequiredArgsConstructor
@@ -57,17 +59,10 @@ public class CrewReviewService {
                 alarmRepository.save(Alarm.toEntityFromReview(toUser, fromUser, review, AlarmType.REVIEW_CREW, AlarmType.REVIEW_CREW.getText()));
 
                 //sse 로직
-                if (sseEmitters.containsKey(toUser.getUsername())) {
-                    log.info("모임 종료 후 작동");
-                    SseEmitter sseEmitter = sseEmitters.get(toUser.getUsername());
-                    try {
-                        sseEmitter.send(SseEmitter.event().name("alarm").data(
-                                "리뷰가 등록되었어요! 확인해 보세요!"));
-                    } catch (Exception e) {
-                        sseEmitters.remove(toUser.getUsername());
-                    }
+                if (isUserLogin(toUser.getUsername())) {
+                    SendAlarmToUser(toUser, "리뷰가 등록되었어요! 확인해 보세요!");
                 }
-                
+
             }
         }catch (NullPointerException e){
             log.info("이용자 후기 NullPointerException : 작성 가능한 후기 내용이 없습니다.");

--- a/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.Review.ReviewRequest;
 import teamproject.pocoapoco.domain.dto.crew.review.CrewReviewDetailResponse;
 import teamproject.pocoapoco.domain.dto.crew.review.CrewReviewResponse;
@@ -23,9 +22,8 @@ import teamproject.pocoapoco.repository.part.ParticipationRepository;
 import javax.transaction.Transactional;
 import java.util.List;
 
-import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
-import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.isUserLogin;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/teamproject/pocoapoco/service/CrewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewService.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
 
 
 @Service
@@ -101,17 +102,13 @@ public class CrewService {
             alarmRepository.save(Alarm.toEntityFromFinishCrew(participation.getUser(), crew, AlarmType.LIKE_COMMENT, "모임이 종료되었습니다."));
             log.info("모임 종류 후 username입니다 = {}",participation.getUser().getUsername());
         }
+
         //sse 로직
         for (int i = 0; i < userList.size(); i++) {
-            if (sseEmitters.containsKey(userList.get(i))) {
+            var userKey = userList.get(i);
+            if (sseEmitters.containsKey(userKey)) {
                 log.info("모임 종료 후 작동");
-                SseEmitter sseEmitter = sseEmitters.get(userList.get(i));
-                try {
-                    sseEmitter.send(SseEmitter.event().name("alarm").data(
-                            "모임이 종료되었습니다! 같이 고생한 크루들에게 후기를 남겨보세요!"));
-                } catch (Exception e) {
-                    sseEmitters.remove(userList.get(i));
-                }
+                SendAlarmToUser(userKey, "모임이 종료되었습니다! 같이 고생한 크루들에게 후기를 남겨보세요!");
             }
         }
 

--- a/src/main/java/teamproject/pocoapoco/service/CrewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewService.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.crew.CrewDetailResponse;
 import teamproject.pocoapoco.domain.dto.crew.CrewRequest;
 import teamproject.pocoapoco.domain.dto.crew.CrewResponse;
@@ -34,7 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
 
 
 @Service

--- a/src/main/java/teamproject/pocoapoco/service/FollowService.java
+++ b/src/main/java/teamproject/pocoapoco/service/FollowService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.follow.FollowingResponse;
 import teamproject.pocoapoco.domain.entity.Alarm;
 import teamproject.pocoapoco.domain.entity.Follow;
@@ -21,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/teamproject/pocoapoco/service/FollowService.java
+++ b/src/main/java/teamproject/pocoapoco/service/FollowService.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
 
 @Service
 @RequiredArgsConstructor
@@ -59,15 +60,11 @@ public class FollowService {
             followRepository.save(new Follow(followingUser,user));
             //알림 저장
             alarmRepository.save(Alarm.toEntityFromFollow(user, followingUser, AlarmType.FOLLOW_CREW, AlarmType.FOLLOW_CREW.getText()));
+
             //sse 로직
-            if (sseEmitters.containsKey(user.getUsername())) {
-                SseEmitter sseEmitter = sseEmitters.get(user.getUsername());
-                try {
-                    sseEmitter.send(SseEmitter.event().name("alarm").data(
-                            followingUser.getNickName() + "님이 회원님을 팔로우 합니다💕 "));
-                } catch (Exception e) {
-                    sseEmitters.remove(user.getUsername());
-                }
+            var userKey = user.getUsername();
+            if (sseEmitters.containsKey(userKey)) {
+                SendAlarmToUser(followingUser, "모임이 종료되었습니다! 같이 고생한 크루들에게 후기를 남겨보세요!");
             }
         }
         return new FollowingResponse(user.getUsername(),user.getNickName(),true, user.getImagePath());

--- a/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
@@ -19,8 +19,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 
 import java.util.List;
 
-import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
-import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
+import static teamproject.pocoapoco.util.SseSender.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseSender.isUserLogin;
 
 @Service
 @Slf4j

--- a/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.dto.like.LikeViewResponse;
 import teamproject.pocoapoco.domain.entity.Alarm;
 import teamproject.pocoapoco.domain.entity.Crew;
@@ -20,7 +19,8 @@ import teamproject.pocoapoco.repository.UserRepository;
 
 import java.util.List;
 
-import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.util.SseUtil.SendAlarmToUser;
+import static teamproject.pocoapoco.util.SseUtil.isUserLogin;
 
 @Service
 @Slf4j
@@ -52,16 +52,8 @@ public class LikeViewService {
             likeViewResponse.setLikeCheck(1);
 
             //sse 로직
-            if (sseEmitters.containsKey(crew.getUser().getUsername())) {
-                log.info("userName이 Map으로 등록되어있어 알림 sse 작동됩니다.");
-                log.info("Sse username = {}", crew.getUser().getUsername());
-                SseEmitter sseEmitter = sseEmitters.get(crew.getUser().getUsername());
-                try {
-                    sseEmitter.send(SseEmitter.event().name("alarm").data(
-                            user.getNickName() + "님이 \"" + crew.getTitle() + "\" 모임에 좋아요를 눌렀습니다."));
-                } catch (Exception e) {
-                    sseEmitters.remove(crew.getUser().getUsername());
-                }
+            if (isUserLogin(crew.getUser().getUsername())) {
+                SendAlarmToUser(user, crew, "\" 모임에 좋아요를 눌렀습니다.");
             }
         }
 

--- a/src/main/java/teamproject/pocoapoco/util/SseSender.java
+++ b/src/main/java/teamproject/pocoapoco/util/SseSender.java
@@ -9,7 +9,7 @@ import teamproject.pocoapoco.domain.entity.User;
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
 
 @Slf4j
-public class SseUtil {
+public class SseSender {
     public static boolean isUserLogin(final String username) {
         return sseEmitters.containsKey(username);
     }

--- a/src/main/java/teamproject/pocoapoco/util/SseUtil.java
+++ b/src/main/java/teamproject/pocoapoco/util/SseUtil.java
@@ -1,0 +1,64 @@
+package teamproject.pocoapoco.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import teamproject.pocoapoco.domain.entity.Comment;
+import teamproject.pocoapoco.domain.entity.Crew;
+import teamproject.pocoapoco.domain.entity.User;
+
+import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+
+@Slf4j
+public class SseUtil {
+    public static boolean isUserLogin(final String username) {
+        return sseEmitters.containsKey(username);
+    }
+
+    public static void SendAlarmToUser(final User user, final Crew crew, final String message) {
+        SseEmitter sseEmitter = sseEmitters.get(crew.getUser().getUsername());
+        try {
+            sseEmitter
+                    .send(SseEmitter.event().name("alarm")
+                    .data(user.getNickName() + "님이 \"" + crew.getTitle() + message));
+
+        } catch (Exception e) {
+            sseEmitters.remove(crew.getUser().getUsername());
+        }
+    }
+
+    public static void SendAlarmToUser(final User user, final Comment parentComment, final String message) {
+        SseEmitter sseEmitter = sseEmitters.get(parentComment.getUser().getUsername());
+        try {
+            sseEmitter
+                    .send(SseEmitter.event()
+                    .name("alarm")
+                    .data(user.getNickName() + "님이 \"" + parentComment.getComment() + message));
+        } catch (Exception e) {
+            sseEmitters.remove(parentComment.getUser().getUsername());
+        }
+    }
+
+    public static void SendAlarmToUser(final User toUser, final String message) {
+        SseEmitter sseEmitter = sseEmitters.get(toUser.getUsername());
+        try {
+            sseEmitter
+                    .send(SseEmitter.event()
+                    .name("alarm")
+                    .data(message));
+        } catch (Exception e) {
+            sseEmitters.remove(toUser.getUsername());
+        }
+    }
+
+    public static void SendAlarmToUser(final String toUser, final String message) {
+        SseEmitter sseEmitter = sseEmitters.get(toUser);
+        try {
+            sseEmitter
+                    .send(SseEmitter.event().name("alarm")
+                    .data(message));
+        } catch (Exception e) {
+            sseEmitters.remove(toUser);
+        }
+    }
+
+}


### PR DESCRIPTION
# 기능 구현

- SSE 알림기능이 반복적으로 동작하는 코드를 Static으로 재사용하고자 코드 리펙토링
- 각 댓글,좋아요,글, 리뷰, 팔로우 기능마다 SSE 구현이 달라 Static Method에 메소드오버라이딩 적용

# 주목 포인트

**SseSender클래스를 기준으로 코드리뷰하신다면 이해하기 편하실것입니다.**

SSE 알림을 전송하는 로직이 각 기능마다 반복되고 있었습니다.
반복되는 코드를 함수화하고자 SseSender클래스의 Static 메서드로 처리하여 반복을 줄였습니다.

이로인해 관리하기 어렵던 알림전송 기능이 SseSender안에서 관리가 가능해졌습니다.
앞으로 다른 기능이 생기면 SseSender안에서 새로운 메서드를 추가하거나, 기존 코드를 재사용하면 됩니다.

# 느낀점

## 보안할점
SseSender안에서 Static으로 메서드를 사용하니 각 기능마다 알림전송의 세부구현이 달라 구현이 힘들었습니다.
해결 방안으로 메서드 오버라이딩을 하여 SseSender안에 알림전송기능을 모았습니다.
하지만 알림전송을 재사용하고자 Static 메서드로 만들었는데 
메서드 오버라이딩을 많이하여 가독성이 떨어지는 느낌을 받았습니다.

## 보안방법
앞으로 알림기능이 추가되거나 변경되면 내부구현을 전부 바꿔야합니다.
분명 전에 각기능 Service에서 구현한 알림전송기능보다는 좋지만, 여전히 변화에 유연하지 않다고 느껴졌습니다.
생각해보니 디자인패턴의 전략패턴을 사용하면 될것같습니다.

**알림전송**을 전략으로 각 기능마다 세부전략을 만들어서 관리하면 변화에 유연하게 대쳐할 수 있고
코드 가독성 또한 좋아질것이라고 판단하였습니다.
다음 리펙토링에는 전략패턴을 사용해서 코드의 유연성과 가독성을 높여보겠습니다.