### PR TITLE
refector : @Value어노테이션을 통해 secretKey 주입

### DIFF
--- a/src/main/java/teamproject/pocoapoco/service/UserService.java
+++ b/src/main/java/teamproject/pocoapoco/service/UserService.java
@@ -69,7 +69,7 @@ public class UserService {
         log.info("권한 조회: {}",user.getRole());
 
         //token 발행
-        return new UserLoginResponse(refreshToken, new JwtProvider().generateAccessToken(user));
+        return new UserLoginResponse(refreshToken, jwtProvider.generateAccessToken(user));
     }
 
     public UserJoinResponse saveUser(UserJoinRequest userJoinRequest){
@@ -140,7 +140,7 @@ public class UserService {
         redisTemplate.opsForValue()
                 .set(authentication.getName(), newRefreshToken, expiredTime , TimeUnit.MILLISECONDS);
 
-        return new ReIssueResponse(refreshToken, new JwtProvider().generateAccessToken(user));
+        return new ReIssueResponse(refreshToken, jwtProvider.generateAccessToken(user));
     }
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,6 @@ spring:
 #      region:
 #        static: ap-northeast-2
   main.allow-bean-definition-overriding: true # jpaAuditingHandler 에러 해결
+
 jwt:
-  token:
-    secret: "secreteKey"
+  secret:


### PR DESCRIPTION
# 리펙토링 내용

기존 secretKey가 하드코딩 되어있던 코드를 아래와 같이 @Value어노테이션을 통해 주입하였습니다.
```java
   @Value("${jwt.secret}")
   private String secretKey;
```

# 에러 해결

secretKey에 null값이 들어와서 확인해 보니 
Jwt를 생성할때 new를 사용해 새로 객체를 생성하고있었습니다.
Spring은 애플리케이션 로딩 시점에 스프링 컨테이너 내부에서 모든 빈들을 등록하면서 
@Value 애노테이션 안의 값들을 설정 파일에서 읽어들여 변수에 저장합니다.

즉, 싱글톤이로 관리되는 빈이 아닌 새로 new를 사용하여 생성하게되면 
@Value 애노테이션으로 적용하지 못해  null로 값이 저장됩니다.

Jwt를 맡았던 팀원분의 실수를 미쳐 발견하지 못해서 벌어진 에러였습니다.
그때 당시에는 프로그래밍을 처음배우던 때여서 알지 못했지만 지금이라도 알게되어 다행이라는 생각입니다.

**변경전**
```java
return new UserLoginResponse(refreshToken, new JwtProvider().generateAccessToken(user));
```
**변경후**
```java
return new UserLoginResponse(refreshToken, jwtProvider.generateAccessToken(user));
```

# 느낀점

이미 기능을 구현했고, 잘 작동하는것 같은 코드라도
리펙토링을 해야할 부분이 있는지, 정말 잘 작동하고 있는지 꾸준히 확인하는 습관이 필요한것 같습니다. 