### PR TITLE
refector : 실시간 매칭 리펙토링

### DIFF
--- a/src/main/java/teamproject/pocoapoco/controller/main/api/match/RandomMatchController.java
+++ b/src/main/java/teamproject/pocoapoco/controller/main/api/match/RandomMatchController.java
@@ -1,4 +1,4 @@
-package teamproject.pocoapoco.controller.main.api.sse;
+package teamproject.pocoapoco.controller.main.api.match;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +15,6 @@ import javax.transaction.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class RandomMatchController {
-    //랜던매치 누르면 작동
     private final LiveMatchService liveMatchService;
 
     @PostMapping("/live")

--- a/src/main/java/teamproject/pocoapoco/domain/entity/Crew.java
+++ b/src/main/java/teamproject/pocoapoco/domain/entity/Crew.java
@@ -4,15 +4,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Where;
 import teamproject.pocoapoco.domain.dto.crew.CrewRequest;
 import teamproject.pocoapoco.domain.entity.chat.ChatRoom;
 import teamproject.pocoapoco.domain.entity.part.Participation;
 import teamproject.pocoapoco.enums.SportEnum;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -73,5 +74,27 @@ public class Crew extends BaseEntity{
         this.title = request.getTitle();
         this.content = request.getContent();
         this.crewLimit = request.getCrewLimit();
+    }
+
+    public static Crew makeRandomMatchingCrew(List<User> users, String sport, int crewLimit){
+        return Crew.builder()
+                .imagePath("67id36j0-디폴트.jpg")
+                .strict("청진동 246 D1동 16층, 17층 ")
+                .roadName("서울 종로구 종로3길 17 D1동 16층, 17층")
+                .title(sport + "실시간 매칭🔥")
+                .content(users.stream()
+                        .map(User::getUsername)
+                        .collect(Collectors.joining("님, ", "", "님\n"))
+                        + "실시간 매칭이 성사되었습니다 \n" +
+                        "채팅방에서 시간 장소를 조율해주세요")
+                .crewLimit(crewLimit)
+                .datepick(LocalDateTime.now().toString())
+                .timepick(LocalDateTime.now().toString())
+                .chatRoom(ChatRoom.builder()
+                        .name(sport + "실시간 매칭")
+                        .user(users.get(0)) //user에 참여자중 한명 넣으면 된다.. name = 타이틀이름
+                        .build())
+                .user(users.get(0))  // crew 만들사람
+                .build();
     }
 }

--- a/src/main/java/teamproject/pocoapoco/service/CommentService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentService.java
@@ -18,6 +18,7 @@ import teamproject.pocoapoco.repository.CommentRepository;
 import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 import teamproject.pocoapoco.service.sse.SseSender;
 import teamproject.pocoapoco.service.sse.UserSseKey;
@@ -26,6 +27,7 @@ import java.time.LocalDateTime;
 
 import static teamproject.pocoapoco.enums.AlarmType.ADD_COMMENT;
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.ADD_COMMENT_TO_ACTIVITY;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
 @Transactional
@@ -37,11 +39,7 @@ public class CommentService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public CommentService(final CommentRepository commentRepository,
-                          final UserRepository userRepository,
-                          final CrewRepository crewRepository,
-                          final AlarmRepository alarmRepository,
-                          final SseSender sseSender) {
+    public CommentService(final CommentRepository commentRepository, final UserRepository userRepository, final CrewRepository crewRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.commentRepository = commentRepository;
         this.userRepository = userRepository;
         this.crewRepository = crewRepository;
@@ -78,6 +76,7 @@ public class CommentService {
                         .fromUser(user.getNickName())
                         .targetUser(crew.getTitle())
                         .message(ADD_COMMENT_TO_ACTIVITY)
+                        .alarmTypeEnum(ALARM)
                         .build()
         );
     }

--- a/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CommentViewService.java
@@ -14,6 +14,7 @@ import teamproject.pocoapoco.exception.ErrorCode;
 import teamproject.pocoapoco.repository.AlarmRepository;
 import teamproject.pocoapoco.repository.CommentRepository;
 import teamproject.pocoapoco.repository.UserRepository;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 import teamproject.pocoapoco.service.sse.SseSender;
 import teamproject.pocoapoco.service.sse.UserSseKey;
@@ -21,6 +22,7 @@ import teamproject.pocoapoco.service.sse.UserSseKey;
 import java.util.List;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.ADD_COMMENT_TO_COMMENT;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
 @Transactional
@@ -31,10 +33,7 @@ public class CommentViewService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public CommentViewService(final CommentRepository commentRepository,
-                              final UserRepository userRepository,
-                              final AlarmRepository alarmRepository,
-                              final SseSender sseSender) {
+    public CommentViewService(final CommentRepository commentRepository, final UserRepository userRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.commentRepository = commentRepository;
         this.userRepository = userRepository;
         this.alarmRepository = alarmRepository;
@@ -77,6 +76,7 @@ public class CommentViewService {
                         .fromUser(user.getNickName())
                         .targetUser(parentComment.getComment())
                         .message(ADD_COMMENT_TO_COMMENT)
+                        .alarmTypeEnum(ALARM)
                         .build()
         );
     }

--- a/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewReviewService.java
@@ -17,6 +17,7 @@ import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.CrewReviewRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 import teamproject.pocoapoco.service.sse.SseSender;
 import teamproject.pocoapoco.service.sse.UserSseKey;
@@ -25,6 +26,7 @@ import javax.transaction.Transactional;
 import java.util.List;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.*;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
 @Transactional
@@ -36,11 +38,7 @@ public class CrewReviewService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public CrewReviewService(final UserRepository userRepository,
-                             final CrewRepository crewRepository,
-                             final CrewReviewRepository crewReviewRepository,
-                             final AlarmRepository alarmRepository,
-                             final SseSender sseSender) {
+    public CrewReviewService(final UserRepository userRepository, final CrewRepository crewRepository, final CrewReviewRepository crewReviewRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.userRepository = userRepository;
         this.crewRepository = crewRepository;
         this.crewReviewRepository = crewReviewRepository;
@@ -82,6 +80,7 @@ public class CrewReviewService {
                 ,
                 SseAlarmData.builder()
                         .message(CHECK_REVIEW)
+                        .alarmTypeEnum(ALARM)
                         .build()
         );
     }

--- a/src/main/java/teamproject/pocoapoco/service/CrewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/CrewService.java
@@ -24,6 +24,7 @@ import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.repository.part.ParticipationRepository;
 import teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 import teamproject.pocoapoco.service.sse.SseSender;
 import teamproject.pocoapoco.service.sse.UserSseKey;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.*;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 
 @Service
@@ -47,11 +49,7 @@ public class CrewService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public CrewService(final CrewRepository crewRepository,
-                       final UserRepository userRepository,
-                       final ParticipationRepository participationRepository,
-                       final AlarmRepository alarmRepository,
-                       final SseSender sseSender) {
+    public CrewService(final CrewRepository crewRepository, final UserRepository userRepository, final ParticipationRepository participationRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.crewRepository = crewRepository;
         this.userRepository = userRepository;
         this.participationRepository = participationRepository;
@@ -128,6 +126,7 @@ public class CrewService {
                             .build(),
                     SseAlarmData.builder()
                             .message(ADD_REVIEW_TO_CREWS)
+                            .alarmTypeEnum(ALARM)
                             .build()
             );
         }

--- a/src/main/java/teamproject/pocoapoco/service/FollowService.java
+++ b/src/main/java/teamproject/pocoapoco/service/FollowService.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.*;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.ALARM;
 
 @Service
 @Transactional
@@ -32,10 +33,7 @@ public class FollowService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public FollowService(final UserRepository userRepository,
-                         final FollowRepository followRepository,
-                         final AlarmRepository alarmRepository,
-                         final SseSender sseSender) {
+    public FollowService(final UserRepository userRepository, final FollowRepository followRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.userRepository = userRepository;
         this.followRepository = followRepository;
         this.alarmRepository = alarmRepository;
@@ -84,8 +82,9 @@ public class FollowService {
                         .userSseKey(user.getUsername())
                         .build(),
                 SseAlarmData.builder()
-                        .targetUser(followingUser.getNickName())
+                        .fromUser(followingUser.getNickName())
                         .message(FOLLOW)
+                        .alarmTypeEnum(ALARM)
                         .build()
         );
     }

--- a/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
+++ b/src/main/java/teamproject/pocoapoco/service/LikeViewService.java
@@ -16,6 +16,7 @@ import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.LikeRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 import teamproject.pocoapoco.service.sse.SseSender;
 import teamproject.pocoapoco.service.sse.UserSseKey;
@@ -23,6 +24,7 @@ import teamproject.pocoapoco.service.sse.UserSseKey;
 import java.util.List;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmMessagesEnum.*;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
 @Slf4j
@@ -34,11 +36,7 @@ public class LikeViewService {
     private final AlarmRepository alarmRepository;
     private final SseSender sseSender;
 
-    public LikeViewService(final LikeRepository likeRepository,
-                           final CrewRepository crewRepository,
-                           final UserRepository userRepository,
-                           final AlarmRepository alarmRepository,
-                           final SseSender sseSender) {
+    public LikeViewService(final LikeRepository likeRepository, final CrewRepository crewRepository, final UserRepository userRepository, final AlarmRepository alarmRepository, final SseSender sseSender) {
         this.likeRepository = likeRepository;
         this.crewRepository = crewRepository;
         this.userRepository = userRepository;
@@ -86,6 +84,7 @@ public class LikeViewService {
                         .fromUser(user.getNickName())
                         .targetUser(crew.getTitle())
                         .message(LIKE)
+                        .alarmTypeEnum(ALARM)
                         .build()
         );
     }

--- a/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
+++ b/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
@@ -1,6 +1,5 @@
 package teamproject.pocoapoco.service.livematch;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
@@ -15,107 +14,94 @@ import teamproject.pocoapoco.exception.ErrorCode;
 import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.repository.part.ParticipationRepository;
+import teamproject.pocoapoco.service.sse.SseSender;
+import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
 
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.*;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
+import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class LiveMatchService {
     private final UserRepository userRepository;
     private final CrewRepository crewRepository;
     private final ParticipationRepository participationRepository;
     private final RedisTemplate<String, String> redisTemplate;
+
+    private final SseSender sseSender;
     private HashMap<String, String> usersSports = new HashMap<>();
-    private String liveMath = "_liveMatch";
+    private static String LIVE_MATCH = "_liveMatch";
+    private static int CREW_LIMIT = 3;
+
+    public LiveMatchService(final UserRepository userRepository,
+                            final CrewRepository crewRepository,
+                            final ParticipationRepository participationRepository,
+                            final RedisTemplate<String, String> redisTemplate,
+                            final SseSender sseSender) {
+        this.userRepository = userRepository;
+        this.crewRepository = crewRepository;
+        this.participationRepository = participationRepository;
+        this.redisTemplate = redisTemplate;
+        this.sseSender = sseSender;
+    }
 
 
     @Transactional
     public int randomMatch(String username, String sport) {
-
         log.info("==================실시간 매칭 Service 로직에 들어왔습니다 - username = {}, sport = {}", username, sport);
-        //처음에는 리스트로 하려고 했지만, 중복을 확인하는데 한계가 있어서 sorted set 사용
 
-        // redis에 대기열 순서대로 삽입, 현재 시간을 score로 잡음
-        redisTemplate.opsForZSet().add(sport, username, System.currentTimeMillis());
+        redisTemplate
+                .opsForZSet()
+                .add(
+                        sport,
+                        username,
+                        System.currentTimeMillis()
+                );
+
         // logout시에 sport를 확인하기 위해 저장 -> 스케일 아웃이 되면 공유가 안되기에 Redis로 리펙토링 예정
-        usersSports.put(username + liveMath, sport);
+        usersSports.put(username + LIVE_MATCH, sport);
 
         // 현재 대기열의 총 숫자 확인
-        Long randomMatchListInRedis = redisTemplate.opsForZSet().zCard(sport);
-        log.info("현재 redis 의 {} 종목 대기열의 숫자는 : {} 입니다",sport  ,randomMatchListInRedis);
+        Long matchingUsersCnt = redisTemplate
+                .opsForZSet()
+                .zCard(sport);
+        log.info("현재 redis 의 {} 종목 대기열의 숫자는 : {} 입니다", sport, matchingUsersCnt);
 
         //대기인원을 sport 종목에 따라 UI에 뿌려주는 로직
         sendSportListCntToUser(sport);
-
-
-
-//         대기리스트에 3명이 들어왔다면
-        if (randomMatchListInRedis >= 3) {
+        // todo if문을 꼭 써야하나?
+        if (matchingUsersCnt >= CREW_LIMIT) {
             log.info("==========================실시간 매칭 대기열이 3명이상이여서 crew 생성 진입");
+            Set<String> usersToRandomMatch = redisTemplate
+                    .opsForZSet()
+                    .range(sport, 0, CREW_LIMIT);
 
-            // 대기열에 있는 User들의 name을 넣기위해 선언 -> redis에서 삭제, user 찾을때 사용
-            String[] UserListInRedis = new String[4];
+            final String[] userNames = usersToRandomMatch
+                    .stream()
+                    .toArray(String[]::new);
+            final User[] users = findUser(userNames);
 
-            // 대기열의 User들을 확인하기 위한 iterator
-            Set<String> range = redisTemplate.opsForZSet().range(sport, 0, 3);
-
-            Iterator<String> iterator = range.iterator();
-            // iterator 돌면서 user string 으로 저장 -> user 찾기 위해
-            int listCnt = 0;
-            while (iterator.hasNext()) {
-                String next = iterator.next();
-                log.info("next = {}", next);
-                UserListInRedis[listCnt] = next;
-                log.info("redis의 대기열 = {}",UserListInRedis[listCnt]);
-                listCnt++;
-            }
-
-            // User를 찾는다 -> 모임을 만들기 위해
-            User fistUser = findUserFromRedis(UserListInRedis[0]);
-            User secondUser = findUserFromRedis(UserListInRedis[1]);
-            User thirdUser = findUserFromRedis(UserListInRedis[2]);
-
-
-            Crew savedLiveMatchCrew = makeCrew(fistUser, secondUser, thirdUser, sport);
-
+            Crew savedLiveMatchCrew = makeCrew(users, sport);
             // participations 만들고 저장 후 crew에 저장
-            makeParticipationsAndUpdateToCrew(fistUser, secondUser, thirdUser, savedLiveMatchCrew, sport);
-
-            deleteRedisLiveMatchLists(UserListInRedis, sport);
-
-            sendSseToUsers(fistUser, secondUser, thirdUser, savedLiveMatchCrew);
+            makeParticipationsAndUpdateToCrew(users, savedLiveMatchCrew, sport);
+            deleteRedisLiveMatchLists(userNames, sport);
+            sendSseToUsers(users, savedLiveMatchCrew);
 
             // 대기리스트 확인
-            log.info("삭제된 후 redis 대기열 : {}",redisTemplate.opsForZSet().zCard(sport));
+            log.info("삭제된 후 redis 대기열 : {}", redisTemplate.opsForZSet().zCard(sport));
         }
         return 1;
     }
 
-    private void sendSse(User user, Crew savedLiveMatchCrew) {
-        //sse 로직
-        if (sseEmitters.containsKey(user.getUsername())) {
-            log.info("실시간매칭 후 sse firstUser 작동");
-            SseEmitter sseEmitter = sseEmitters.get(user.getUsername());
-            try {
-                sseEmitter.send(SseEmitter.event().name("liveMatch").data(
-                        savedLiveMatchCrew.getChatRoom().getRoomId() + " " + savedLiveMatchCrew.getId()));
-            } catch (Exception e) {
-                sseEmitters.remove(savedLiveMatchCrew.getUser().getUsername());
-            }
-        }
-    }
-    private void sendSseToUsers(User fistUser, User secondUser, User thirdUser, Crew savedLiveMatchCrew) {
-        //sse 로직
-        //유저들을 String[]로 리펙토링해서 for문을 돌려보다
-        //sendSse() 도 static으로 선언하면 조금 더 리펙토링 할 수 있지 않을까??
-        sendSse(fistUser, savedLiveMatchCrew);
-        sendSse(secondUser, savedLiveMatchCrew);
-        sendSse(thirdUser, savedLiveMatchCrew);
+    private void sendSseToUsers(User[] users, Crew savedLiveMatchCrew) {
+        //todo SseSender 사용
+        sendSse(users[0], savedLiveMatchCrew);
+        sendSse(users[1], savedLiveMatchCrew);
+        sendSse(users[2], savedLiveMatchCrew);
     }
 
     private void deleteRedisLiveMatchLists(String[] UserListInRedis, String sport) {
@@ -125,36 +111,17 @@ public class LiveMatchService {
         redisTemplate.opsForZSet().remove(sport, UserListInRedis[2]);
 
         //hashMap에서 user sports 삭제
-        usersSports.remove(UserListInRedis[0] + liveMath);
-        usersSports.remove(UserListInRedis[1] + liveMath);
-        usersSports.remove(UserListInRedis[2] + liveMath);
-
+        usersSports.remove(UserListInRedis[0] + LIVE_MATCH);
+        usersSports.remove(UserListInRedis[1] + LIVE_MATCH);
+        usersSports.remove(UserListInRedis[2] + LIVE_MATCH);
     }
 
-    private void makeParticipationsAndUpdateToCrew(User fistUser, User secondUser, User thirdUser, Crew savedLiveMatchCrew, String sport) {
+    private void makeParticipationsAndUpdateToCrew(User[] users, Crew savedLiveMatchCrew, String sport) {
         // participations 만들기
         List<Participation> participationList = new ArrayList<>();
-
-        Participation firstParticipation = Participation.builder()
-                .status(2)
-                .user(fistUser)
-                .crew(savedLiveMatchCrew)
-                .title(sport + "실시간 매칭🔥")
-                .build();
-
-        Participation secParticipation = Participation.builder()
-                .status(2)
-                .user(secondUser)
-                .crew(savedLiveMatchCrew)
-                .title(sport + "실시간 매칭🔥")
-                .build();
-
-        Participation thirdParticipation = Participation.builder()
-                .status(2)
-                .user(thirdUser)
-                .crew(savedLiveMatchCrew)
-                .title(sport + "실시간 매칭🔥")
-                .build();
+        Participation firstParticipation = makeParticipation(savedLiveMatchCrew, sport, users[0]);
+        Participation secParticipation = makeParticipation(savedLiveMatchCrew, sport, users[1]);
+        Participation thirdParticipation = makeParticipation(savedLiveMatchCrew, sport, users[2]);
 
         // participation 저장
         participationRepository.save(firstParticipation);
@@ -170,69 +137,97 @@ public class LiveMatchService {
         savedLiveMatchCrew.setParticipations(participationList);
     }
 
+    private static Participation makeParticipation(final Crew savedLiveMatchCrew, final String sport, final User firstUser) {
+        // todo Participation status 상태 Enum으로 가독성 높이기
+        return Participation.builder()
+                .status(2)
+                .user(firstUser)
+                .crew(savedLiveMatchCrew)
+                .title(sport + "실시간 매칭🔥")
+                .build();
+    }
 
 
-    private Crew makeCrew(User fistUser, User secondUser, User thirdUser, String sport) {
+    private Crew makeCrew(User[] users, String sport) {
         // 방을 만들고 채팅방을 생성
         Crew crew = Crew.builder()
                 .imagePath("67id36j0-디폴트.jpg")
                 .strict("청진동 246 D1동 16층, 17층 ")
                 .roadName("서울 종로구 종로3길 17 D1동 16층, 17층")
                 .title(sport + "실시간 매칭🔥")
-                .content(fistUser.getUsername() + "님, " + secondUser.getUsername() + "님, "
-                        + thirdUser.getUsername()  + "님\n"
+                .content(users[0].getUsername() + "님, "
+                        + users[1].getUsername() + "님, "
+                        + users[2].getUsername() + "님\n"
                         + "실시간 매칭이 성사되었습니다 \n" +
                         "채팅방에서 시간 장소를 조율해주세요")
-                .crewLimit(3)
+                .crewLimit(CREW_LIMIT)
                 .datepick(LocalDateTime.now().toString())
                 .timepick(LocalDateTime.now().toString())
                 .chatRoom(ChatRoom.builder()
                         .name(sport + "실시간 매칭")
-                        .user(fistUser)
+                        .user(users[0])
                         .build()) //user에 참여자중 한명 넣으면 된다.. name = 타이틀이름
-                .user(fistUser)  // crew 만든사람
+                .user(users[0])  // crew 만든사람
                 .build();
         return crewRepository.save(crew);
     }
+
     private void sendSseToSportUser(List<String> user) {
         //sse 로직
-
         for (int i = 0; i < user.size(); i++) {
             if (sseEmitters.containsKey(user.get(i))) {
                 log.info("실시간매칭 sport에 user들에게 대기인원 수 출력");
                 SseEmitter sseEmitter = sseEmitters.get(user.get(i));
                 try {
-                    sseEmitter.send(SseEmitter.event().name("liveMatchCnt").data(
-                            user.size()));
+                    sseEmitter
+                            .send(SseEmitter
+                                    .event()
+                                    .name(LIVE_MATCH_PARTICIPANT_CNT.getValue())
+                                    .data(user.size()));
                 } catch (Exception e) {
                     sseEmitters.remove(user.get(i));
                 }
             }
         }
-
-
     }
+
+    private void sendSse(User user, Crew savedLiveMatchCrew) {
+        //sse 로직
+        if (sseEmitters.containsKey(user.getUsername())) {
+            log.info("실시간매칭 후 sse firstUser 작동");
+            SseEmitter sseEmitter = sseEmitters.get(user.getUsername());
+            try {
+                sseEmitter
+                        .send(SseEmitter
+                                .event()
+                                .name(AlarmTypeEnum.LIVE_MATCH.getValue())
+                                .data(savedLiveMatchCrew.getChatRoom().getRoomId() + " " + savedLiveMatchCrew.getId()));
+            } catch (Exception e) {
+                sseEmitters.remove(savedLiveMatchCrew.getUser().getUsername());
+            }
+        }
+    }
+
     public void sendSportListCntToUser(String sport) {
         List<String> users = new ArrayList<>();
         for (String user : usersSports.keySet()) {
-            if(usersSports.get(user).equals(sport)){
-                String[] name = user.split(liveMath);
+            if (usersSports.get(user).equals(sport)) {
+                String[] name = user.split(LIVE_MATCH);
                 users.add(name[0]);
             }
         }
-        log.info("sport 안에있는 users = {}", users.toString());
+        log.info("sport 안에있는 users = {}", users);
         sendSseToSportUser(users);
     }
 
     @Transactional
     public int randomMatchCancel(@RequestParam String username) {
-        String sport = usersSports.get(username + liveMath);
+        String sport = usersSports.get(username + LIVE_MATCH);
         log.info("sport = {}", sport);
         // redis에 있는 userName을 삭제
         redisTemplate.opsForZSet().remove(sport, username);
         log.info("logout user = {}", username);
-//        redisTemplate.delete(username + liveMath);
-        usersSports.remove(username + liveMath);
+        usersSports.remove(username + LIVE_MATCH);
         //대기열 숫자 전송
         sendSportListCntToUser(sport);
 
@@ -244,8 +239,10 @@ public class LiveMatchService {
             log.info("실시간 매칭 취소 -> 대기인원 정보 안보이게하기");
             SseEmitter sseEmitter = sseEmitters.get(username);
             try {
-                sseEmitter.send(SseEmitter.event().name("liveMatchCancel").data(
-                        1));
+                sseEmitter.send(SseEmitter
+                        .event()
+                        .name(LIVE_MATCH_CANCEL.getValue())
+                        .data(1));
             } catch (Exception e) {
                 sseEmitters.remove(username);
             }
@@ -254,10 +251,13 @@ public class LiveMatchService {
         return 1;
     }
 
-    private User findUserFromRedis(String UserListInRedis) {
-        return userRepository.findByUserName(UserListInRedis).orElseThrow(() -> {
-            return new AppException(ErrorCode.USERID_NOT_FOUND, ErrorCode.USERID_NOT_FOUND.getMessage());
-        });
+    private User[] findUser(String[] UserListInRedis) {
+        User[] users = new User[CREW_LIMIT];
+        for (int i = 0; i < CREW_LIMIT; i++) {
+            users[i] = userRepository.findByUserName(UserListInRedis[i]).orElseThrow(() -> {
+                return new AppException(ErrorCode.USERID_NOT_FOUND, ErrorCode.USERID_NOT_FOUND.getMessage());
+            });
+        }
+        return users;
     }
-
 }

--- a/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
+++ b/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
@@ -4,10 +4,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.domain.entity.Crew;
 import teamproject.pocoapoco.domain.entity.User;
-import teamproject.pocoapoco.domain.entity.chat.ChatRoom;
 import teamproject.pocoapoco.domain.entity.part.Participation;
 import teamproject.pocoapoco.exception.AppException;
 import teamproject.pocoapoco.exception.ErrorCode;
@@ -15,13 +13,14 @@ import teamproject.pocoapoco.repository.CrewRepository;
 import teamproject.pocoapoco.repository.UserRepository;
 import teamproject.pocoapoco.repository.part.ParticipationRepository;
 import teamproject.pocoapoco.service.sse.SseSender;
+import teamproject.pocoapoco.service.sse.UserSseKey;
 import teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum;
+import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 
 import javax.transaction.Transactional;
-import java.time.LocalDateTime;
 import java.util.*;
+import java.util.stream.Collectors;
 
-import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
 import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
 @Service
@@ -34,14 +33,10 @@ public class LiveMatchService {
 
     private final SseSender sseSender;
     private HashMap<String, String> usersSports = new HashMap<>();
-    private static String LIVE_MATCH = "_liveMatch";
+    private static String _LIVE_MATCH = "_liveMatch";
     private static int CREW_LIMIT = 3;
 
-    public LiveMatchService(final UserRepository userRepository,
-                            final CrewRepository crewRepository,
-                            final ParticipationRepository participationRepository,
-                            final RedisTemplate<String, String> redisTemplate,
-                            final SseSender sseSender) {
+    public LiveMatchService(final UserRepository userRepository, final CrewRepository crewRepository, final ParticipationRepository participationRepository, final RedisTemplate<String, String> redisTemplate, final SseSender sseSender) {
         this.userRepository = userRepository;
         this.crewRepository = crewRepository;
         this.participationRepository = participationRepository;
@@ -49,47 +44,29 @@ public class LiveMatchService {
         this.sseSender = sseSender;
     }
 
-
     @Transactional
     public int randomMatch(String username, String sport) {
         log.info("==================실시간 매칭 Service 로직에 들어왔습니다 - username = {}, sport = {}", username, sport);
-
-        redisTemplate
-                .opsForZSet()
-                .add(
-                        sport,
-                        username,
-                        System.currentTimeMillis()
-                );
+        redisTemplate.opsForZSet().add(sport, username, System.currentTimeMillis());
 
         // logout시에 sport를 확인하기 위해 저장 -> 스케일 아웃이 되면 공유가 안되기에 Redis로 리펙토링 예정
-        usersSports.put(username + LIVE_MATCH, sport);
-
-        // 현재 대기열의 총 숫자 확인
-        Long matchingUsersCnt = redisTemplate
-                .opsForZSet()
-                .zCard(sport);
+        // todo redis에 username이 아닌 User를 넣으면 삭제를 위한 Map이 필요 없지 않을까?
+        usersSports.put(username + _LIVE_MATCH, sport);
+        Long matchingUsersCnt = redisTemplate.opsForZSet().zCard(sport);
         log.info("현재 redis 의 {} 종목 대기열의 숫자는 : {} 입니다", sport, matchingUsersCnt);
 
         //대기인원을 sport 종목에 따라 UI에 뿌려주는 로직
-        sendSportListCntToUser(sport);
-        // todo if문을 꼭 써야하나?
+        sendSportListCntToWaitingUsers(sport);
+
         if (matchingUsersCnt >= CREW_LIMIT) {
             log.info("==========================실시간 매칭 대기열이 3명이상이여서 crew 생성 진입");
-            Set<String> usersToRandomMatch = redisTemplate
-                    .opsForZSet()
-                    .range(sport, 0, CREW_LIMIT);
+            final List<User> users = findUser(redisTemplate.opsForZSet().range(sport, 0, CREW_LIMIT));
 
-            final String[] userNames = usersToRandomMatch
-                    .stream()
-                    .toArray(String[]::new);
-            final User[] users = findUser(userNames);
-
-            Crew savedLiveMatchCrew = makeCrew(users, sport);
+            Crew savedLiveMatchCrew = crewRepository.save(Crew.makeRandomMatchingCrew(users, sport, CREW_LIMIT));
             // participations 만들고 저장 후 crew에 저장
-            makeParticipationsAndUpdateToCrew(users, savedLiveMatchCrew, sport);
-            deleteRedisLiveMatchLists(userNames, sport);
-            sendSseToUsers(users, savedLiveMatchCrew);
+            makeParticipationAndUpdateToCrew(users, savedLiveMatchCrew, sport);
+            deleteRedisLiveMatchLists(users, sport);
+            sendSseToUsersAfterMatching(users, savedLiveMatchCrew);
 
             // 대기리스트 확인
             log.info("삭제된 후 redis 대기열 : {}", redisTemplate.opsForZSet().zCard(sport));
@@ -97,167 +74,97 @@ public class LiveMatchService {
         return 1;
     }
 
-    private void sendSseToUsers(User[] users, Crew savedLiveMatchCrew) {
-        //todo SseSender 사용
-        sendSse(users[0], savedLiveMatchCrew);
-        sendSse(users[1], savedLiveMatchCrew);
-        sendSse(users[2], savedLiveMatchCrew);
+    private void deleteRedisLiveMatchLists(List<User> users, String sport) {
+        users.stream()
+                .map(User::getUsername)
+                .forEach(userName -> {
+                    redisTemplate.opsForZSet().remove(sport, userName);
+                    usersSports.remove(userName + _LIVE_MATCH);
+                });
     }
 
-    private void deleteRedisLiveMatchLists(String[] UserListInRedis, String sport) {
-        // 랜덤매칭이 이루어진 3명을 대기리스트에서 삭제
-        redisTemplate.opsForZSet().remove(sport, UserListInRedis[0]);
-        redisTemplate.opsForZSet().remove(sport, UserListInRedis[1]);
-        redisTemplate.opsForZSet().remove(sport, UserListInRedis[2]);
-
-        //hashMap에서 user sports 삭제
-        usersSports.remove(UserListInRedis[0] + LIVE_MATCH);
-        usersSports.remove(UserListInRedis[1] + LIVE_MATCH);
-        usersSports.remove(UserListInRedis[2] + LIVE_MATCH);
-    }
-
-    private void makeParticipationsAndUpdateToCrew(User[] users, Crew savedLiveMatchCrew, String sport) {
-        // participations 만들기
+    private void makeParticipationAndUpdateToCrew(List<User> users, Crew savedLiveMatchCrew, String sport) {
         List<Participation> participationList = new ArrayList<>();
-        Participation firstParticipation = makeParticipation(savedLiveMatchCrew, sport, users[0]);
-        Participation secParticipation = makeParticipation(savedLiveMatchCrew, sport, users[1]);
-        Participation thirdParticipation = makeParticipation(savedLiveMatchCrew, sport, users[2]);
-
-        // participation 저장
-        participationRepository.save(firstParticipation);
-        participationRepository.save(secParticipation);
-        participationRepository.save(thirdParticipation);
-
-        // list에 저장
-        participationList.add(firstParticipation);
-        participationList.add(secParticipation);
-        participationList.add(thirdParticipation);
-
-        //저장된 크루에 participations 저장
+        users.stream().forEach(user
+                -> participationList.add(makeParticipation(savedLiveMatchCrew, sport, user)
+        ));
+        participationRepository.saveAll(participationList);
         savedLiveMatchCrew.setParticipations(participationList);
     }
 
-    private static Participation makeParticipation(final Crew savedLiveMatchCrew, final String sport, final User firstUser) {
-        // todo Participation status 상태 Enum으로 가독성 높이기
+    private Participation makeParticipation(final Crew savedLiveMatchCrew, final String sport, final User firstUser) {
         return Participation.builder()
-                .status(2)
+                .status(2) // todo Participation status 상태 Enum으로 가독성 높이기
                 .user(firstUser)
                 .crew(savedLiveMatchCrew)
                 .title(sport + "실시간 매칭🔥")
                 .build();
     }
 
-
-    private Crew makeCrew(User[] users, String sport) {
-        // 방을 만들고 채팅방을 생성
-        Crew crew = Crew.builder()
-                .imagePath("67id36j0-디폴트.jpg")
-                .strict("청진동 246 D1동 16층, 17층 ")
-                .roadName("서울 종로구 종로3길 17 D1동 16층, 17층")
-                .title(sport + "실시간 매칭🔥")
-                .content(users[0].getUsername() + "님, "
-                        + users[1].getUsername() + "님, "
-                        + users[2].getUsername() + "님\n"
-                        + "실시간 매칭이 성사되었습니다 \n" +
-                        "채팅방에서 시간 장소를 조율해주세요")
-                .crewLimit(CREW_LIMIT)
-                .datepick(LocalDateTime.now().toString())
-                .timepick(LocalDateTime.now().toString())
-                .chatRoom(ChatRoom.builder()
-                        .name(sport + "실시간 매칭")
-                        .user(users[0])
-                        .build()) //user에 참여자중 한명 넣으면 된다.. name = 타이틀이름
-                .user(users[0])  // crew 만든사람
-                .build();
-        return crewRepository.save(crew);
-    }
-
-    private void sendSseToSportUser(List<String> user) {
-        //sse 로직
-        for (int i = 0; i < user.size(); i++) {
-            if (sseEmitters.containsKey(user.get(i))) {
-                log.info("실시간매칭 sport에 user들에게 대기인원 수 출력");
-                SseEmitter sseEmitter = sseEmitters.get(user.get(i));
-                try {
-                    sseEmitter
-                            .send(SseEmitter
-                                    .event()
-                                    .name(LIVE_MATCH_PARTICIPANT_CNT.getValue())
-                                    .data(user.size()));
-                } catch (Exception e) {
-                    sseEmitters.remove(user.get(i));
-                }
-            }
-        }
-    }
-
-    private void sendSse(User user, Crew savedLiveMatchCrew) {
-        //sse 로직
-        if (sseEmitters.containsKey(user.getUsername())) {
-            log.info("실시간매칭 후 sse firstUser 작동");
-            SseEmitter sseEmitter = sseEmitters.get(user.getUsername());
-            try {
-                sseEmitter
-                        .send(SseEmitter
-                                .event()
-                                .name(AlarmTypeEnum.LIVE_MATCH.getValue())
-                                .data(savedLiveMatchCrew.getChatRoom().getRoomId() + " " + savedLiveMatchCrew.getId()));
-            } catch (Exception e) {
-                sseEmitters.remove(savedLiveMatchCrew.getUser().getUsername());
-            }
-        }
-    }
-
-    public void sendSportListCntToUser(String sport) {
-        List<String> users = new ArrayList<>();
-        for (String user : usersSports.keySet()) {
-            if (usersSports.get(user).equals(sport)) {
-                String[] name = user.split(LIVE_MATCH);
-                users.add(name[0]);
-            }
-        }
-        log.info("sport 안에있는 users = {}", users);
-        sendSseToSportUser(users);
-    }
-
     @Transactional
     public int randomMatchCancel(@RequestParam String username) {
-        String sport = usersSports.get(username + LIVE_MATCH);
-        log.info("sport = {}", sport);
+        String sport = usersSports.get(username + _LIVE_MATCH);
+//        log.info("sport = {}", sport);
         // redis에 있는 userName을 삭제
         redisTemplate.opsForZSet().remove(sport, username);
-        log.info("logout user = {}", username);
-        usersSports.remove(username + LIVE_MATCH);
-        //대기열 숫자 전송
-        sendSportListCntToUser(sport);
+//        log.info("logout user = {}", username);
+        usersSports.remove(username + _LIVE_MATCH);
+        //취소 후 대기열 숫자 전송
+        sendSportListCntToWaitingUsers(sport);
 
         Long randomMatchListInRedisCnt = redisTemplate.opsForZSet().zCard(sport);
         log.info("현재 redis의 대기열의 숫자는 : {} 입니다", randomMatchListInRedisCnt);
 
-        //sse 로직
-        if (sseEmitters.containsKey(username)) {
-            log.info("실시간 매칭 취소 -> 대기인원 정보 안보이게하기");
-            SseEmitter sseEmitter = sseEmitters.get(username);
-            try {
-                sseEmitter.send(SseEmitter
-                        .event()
-                        .name(LIVE_MATCH_CANCEL.getValue())
-                        .data(1));
-            } catch (Exception e) {
-                sseEmitters.remove(username);
-            }
-        }
-
+        // 매칭 취소 후 매칭 중인 정보 cnt 줄이기
+        sendSse(username, "", LIVE_MATCH_CANCEL);
         return 1;
     }
 
-    private User[] findUser(String[] UserListInRedis) {
-        User[] users = new User[CREW_LIMIT];
-        for (int i = 0; i < CREW_LIMIT; i++) {
-            users[i] = userRepository.findByUserName(UserListInRedis[i]).orElseThrow(() -> {
-                return new AppException(ErrorCode.USERID_NOT_FOUND, ErrorCode.USERID_NOT_FOUND.getMessage());
-            });
+    private List<User> findUser(Set<String> userListInRedis) {
+        // todo orElseThrow를 써야 안전한 코드가 될것 같다...
+//        return userListInRedis.stream()
+//                .map(userRepository::findByUserName)
+//                .map(Optional::get)
+//                .collect(Collectors.toList());
+
+        List<User> users = new ArrayList<>();
+        for (String userName : userListInRedis) {
+            users.add(userRepository.findByUserName(userName).orElseThrow(
+                    () -> new AppException(ErrorCode.USERID_NOT_FOUND, ErrorCode.USERID_NOT_FOUND.getMessage())
+            ));
         }
         return users;
+    }
+
+    private void sendSse(String userName, String data, AlarmTypeEnum alarmTypeEnum) {
+        sseSender.sendAlarmRandomMatch(
+                UserSseKey.builder()
+                        .userSseKey(userName)
+                        .build(),
+                SseAlarmData.builder()
+                        .data(data)
+                        .alarmTypeEnum(alarmTypeEnum)
+                        .build()
+        );
+    }
+
+    private void sendSseToUsersAfterMatching(List<User> users, Crew savedLiveMatchCrew) {
+        for (User user : users) {
+            final String randomMatchChattingRoomURI = savedLiveMatchCrew.getChatRoom().getRoomId() + " " + savedLiveMatchCrew.getId();
+            sendSse(user.getUsername(), randomMatchChattingRoomURI, LIVE_MATCH);
+        }
+    }
+
+    public void sendSportListCntToWaitingUsers(String sport) {
+        List<String> usersName = new ArrayList<>();
+        for (String user : usersSports.keySet()) {
+            if (usersSports.get(user).equals(sport)) {
+                String[] name = user.split(_LIVE_MATCH);
+                usersName.add(name[0]);
+            }
+        }
+        log.info("sport 안에있는 usersName = {}", usersName);
+        usersName.forEach(
+                userName -> sendSse(userName, String.valueOf(usersName.size()), LIVE_MATCH_WAITING_CNT));
     }
 }

--- a/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
+++ b/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java
@@ -19,7 +19,6 @@ import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 
 import javax.transaction.Transactional;
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.*;
 
@@ -30,9 +29,7 @@ public class LiveMatchService {
     private final CrewRepository crewRepository;
     private final ParticipationRepository participationRepository;
     private final RedisTemplate<String, String> redisTemplate;
-
     private final SseSender sseSender;
-    private HashMap<String, String> usersSports = new HashMap<>();
     private static String _LIVE_MATCH = "_liveMatch";
     private static int CREW_LIMIT = 3;
 
@@ -48,27 +45,21 @@ public class LiveMatchService {
     public int randomMatch(String username, String sport) {
         log.info("==================실시간 매칭 Service 로직에 들어왔습니다 - username = {}, sport = {}", username, sport);
         redisTemplate.opsForZSet().add(sport, username, System.currentTimeMillis());
+        redisTemplate.opsForSet().add(username + _LIVE_MATCH, sport);
 
-        // logout시에 sport를 확인하기 위해 저장 -> 스케일 아웃이 되면 공유가 안되기에 Redis로 리펙토링 예정
-        // todo redis에 username이 아닌 User를 넣으면 삭제를 위한 Map이 필요 없지 않을까?
-        usersSports.put(username + _LIVE_MATCH, sport);
-        Long matchingUsersCnt = redisTemplate.opsForZSet().zCard(sport);
-        log.info("현재 redis 의 {} 종목 대기열의 숫자는 : {} 입니다", sport, matchingUsersCnt);
-
-        //대기인원을 sport 종목에 따라 UI에 뿌려주는 로직
         sendSportListCntToWaitingUsers(sport);
 
+        Long matchingUsersCnt = redisTemplate.opsForZSet().zCard(sport);
         if (matchingUsersCnt >= CREW_LIMIT) {
             log.info("==========================실시간 매칭 대기열이 3명이상이여서 crew 생성 진입");
             final List<User> users = findUser(redisTemplate.opsForZSet().range(sport, 0, CREW_LIMIT));
-
+            // todo 메서드의 매개변수가 중복되는것을 객체화 할 수는 없을까?
             Crew savedLiveMatchCrew = crewRepository.save(Crew.makeRandomMatchingCrew(users, sport, CREW_LIMIT));
             // participations 만들고 저장 후 crew에 저장
             makeParticipationAndUpdateToCrew(users, savedLiveMatchCrew, sport);
             deleteRedisLiveMatchLists(users, sport);
-            sendSseToUsersAfterMatching(users, savedLiveMatchCrew);
+            sendSseToUsersAfterMatchingAndRedirectToChattingRoom(users, savedLiveMatchCrew);
 
-            // 대기리스트 확인
             log.info("삭제된 후 redis 대기열 : {}", redisTemplate.opsForZSet().zCard(sport));
         }
         return 1;
@@ -79,13 +70,13 @@ public class LiveMatchService {
                 .map(User::getUsername)
                 .forEach(userName -> {
                     redisTemplate.opsForZSet().remove(sport, userName);
-                    usersSports.remove(userName + _LIVE_MATCH);
+//                    usersSports.remove(userName + _LIVE_MATCH);
                 });
     }
 
     private void makeParticipationAndUpdateToCrew(List<User> users, Crew savedLiveMatchCrew, String sport) {
         List<Participation> participationList = new ArrayList<>();
-        users.stream().forEach(user
+        users.forEach(user
                 -> participationList.add(makeParticipation(savedLiveMatchCrew, sport, user)
         ));
         participationRepository.saveAll(participationList);
@@ -103,30 +94,15 @@ public class LiveMatchService {
 
     @Transactional
     public int randomMatchCancel(@RequestParam String username) {
-        String sport = usersSports.get(username + _LIVE_MATCH);
-//        log.info("sport = {}", sport);
-        // redis에 있는 userName을 삭제
+        final String sport = redisTemplate.opsForSet().pop(username + _LIVE_MATCH);
         redisTemplate.opsForZSet().remove(sport, username);
-//        log.info("logout user = {}", username);
-        usersSports.remove(username + _LIVE_MATCH);
-        //취소 후 대기열 숫자 전송
+
         sendSportListCntToWaitingUsers(sport);
-
-        Long randomMatchListInRedisCnt = redisTemplate.opsForZSet().zCard(sport);
-        log.info("현재 redis의 대기열의 숫자는 : {} 입니다", randomMatchListInRedisCnt);
-
-        // 매칭 취소 후 매칭 중인 정보 cnt 줄이기
         sendSse(username, "", LIVE_MATCH_CANCEL);
         return 1;
     }
 
     private List<User> findUser(Set<String> userListInRedis) {
-        // todo orElseThrow를 써야 안전한 코드가 될것 같다...
-//        return userListInRedis.stream()
-//                .map(userRepository::findByUserName)
-//                .map(Optional::get)
-//                .collect(Collectors.toList());
-
         List<User> users = new ArrayList<>();
         for (String userName : userListInRedis) {
             users.add(userRepository.findByUserName(userName).orElseThrow(
@@ -148,7 +124,7 @@ public class LiveMatchService {
         );
     }
 
-    private void sendSseToUsersAfterMatching(List<User> users, Crew savedLiveMatchCrew) {
+    private void sendSseToUsersAfterMatchingAndRedirectToChattingRoom(List<User> users, Crew savedLiveMatchCrew) {
         for (User user : users) {
             final String randomMatchChattingRoomURI = savedLiveMatchCrew.getChatRoom().getRoomId() + " " + savedLiveMatchCrew.getId();
             sendSse(user.getUsername(), randomMatchChattingRoomURI, LIVE_MATCH);
@@ -156,14 +132,7 @@ public class LiveMatchService {
     }
 
     public void sendSportListCntToWaitingUsers(String sport) {
-        List<String> usersName = new ArrayList<>();
-        for (String user : usersSports.keySet()) {
-            if (usersSports.get(user).equals(sport)) {
-                String[] name = user.split(_LIVE_MATCH);
-                usersName.add(name[0]);
-            }
-        }
-        log.info("sport 안에있는 usersName = {}", usersName);
+        List<String> usersName = new ArrayList<>(redisTemplate.opsForZSet().range(sport, 0, CREW_LIMIT));
         usersName.forEach(
                 userName -> sendSse(userName, String.valueOf(usersName.size()), LIVE_MATCH_WAITING_CNT));
     }

--- a/src/main/java/teamproject/pocoapoco/service/sse/SseSender.java
+++ b/src/main/java/teamproject/pocoapoco/service/sse/SseSender.java
@@ -5,7 +5,6 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import teamproject.pocoapoco.service.sse.dto.SseAlarmData;
 
 import static teamproject.pocoapoco.controller.main.api.sse.SseController.sseEmitters;
-import static teamproject.pocoapoco.service.sse.dto.AlarmTypeEnum.ALARM;
 
 @Component
 public class SseSender {
@@ -15,7 +14,7 @@ public class SseSender {
             userSseEmitter
                     .send(SseEmitter
                             .event()
-                            .name(ALARM.getValue())
+                            .name(data.getAlarmTypeEnum().getValue())
                             .data(
                                     data.getFromUser()
                                             + "님이 \""
@@ -32,7 +31,7 @@ public class SseSender {
             userSseEmitter
                     .send(SseEmitter
                             .event()
-                            .name(ALARM.getValue())
+                            .name(data.getAlarmTypeEnum().getValue())
                             .data(data.getMessage().getValue()));
         } catch (Exception e) {
             sseEmitters.remove(userSseKey);
@@ -45,8 +44,21 @@ public class SseSender {
             userSseEmitter
                     .send(SseEmitter
                             .event()
-                            .name(ALARM.getValue())
-                            .data(data.getMessage().getValue()));
+                            .name(data.getAlarmTypeEnum().getValue())
+                            .data(data.getFromUser() + data.getMessage().getValue()));
+        } catch (Exception e) {
+            sseEmitters.remove(userSseKey);
+        }
+    }
+
+    public void sendAlarmRandomMatch(final UserSseKey userSseKey, final SseAlarmData data) {
+        SseEmitter userSseEmitter = getUserEmitter(userSseKey.getUserSseKey());
+        try {
+            userSseEmitter
+                    .send(SseEmitter
+                            .event()
+                            .name(data.getAlarmTypeEnum().getValue())
+                            .data(data.getData()));
         } catch (Exception e) {
             sseEmitters.remove(userSseKey);
         }

--- a/src/main/java/teamproject/pocoapoco/service/sse/dto/AlarmTypeEnum.java
+++ b/src/main/java/teamproject/pocoapoco/service/sse/dto/AlarmTypeEnum.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 public enum AlarmTypeEnum {
     ALARM("alarm"),
     LIVE_MATCH("liveMatch"),
-    LIVE_MATCH_PARTICIPANT_CNT("liveMatchCnt"),
+    LIVE_MATCH_WAITING_CNT("liveMatchCnt"),
     LIVE_MATCH_CANCEL("liveMatchCancel")
     ;
 

--- a/src/main/java/teamproject/pocoapoco/service/sse/dto/AlarmTypeEnum.java
+++ b/src/main/java/teamproject/pocoapoco/service/sse/dto/AlarmTypeEnum.java
@@ -6,7 +6,11 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public enum AlarmTypeEnum {
-    ALARM("alarm");
+    ALARM("alarm"),
+    LIVE_MATCH("liveMatch"),
+    LIVE_MATCH_PARTICIPANT_CNT("liveMatchCnt"),
+    LIVE_MATCH_CANCEL("liveMatchCancel")
+    ;
 
     private final String value;
 }

--- a/src/main/java/teamproject/pocoapoco/service/sse/dto/SseAlarmData.java
+++ b/src/main/java/teamproject/pocoapoco/service/sse/dto/SseAlarmData.java
@@ -7,12 +7,16 @@ import lombok.Getter;
 public class SseAlarmData {
     private final String fromUser;
     private final String targetUser;
+    private String data;
     private final AlarmMessagesEnum message;
+    private final AlarmTypeEnum alarmTypeEnum;
 
     @Builder
-    public SseAlarmData(final String fromUser, final String targetUser, final AlarmMessagesEnum message) {
+    public SseAlarmData(final String fromUser, final String targetUser, final String data, final AlarmMessagesEnum message, final AlarmTypeEnum alarmTypeEnum) {
         this.fromUser = fromUser;
         this.targetUser = targetUser;
+        this.data = data;
         this.message = message;
+        this.alarmTypeEnum = alarmTypeEnum;
     }
 }

--- a/src/main/resources/static/js/sse.js
+++ b/src/main/resources/static/js/sse.js
@@ -31,8 +31,8 @@ if (userId.length > 0) {
                 .then(function () {
                     //date 채팅ID " " 크루ID
                     console.log('roomId = ' + split[0] + 'crewId = ' + split[1]);
-                    location.href = "http://ec2-52-79-236-51.ap-northeast-2.compute.amazonaws.com:8080/view/v1/room?roomId=" + split[0] + "&crewId=" + split[1];
-                    // location.href="http://localhost:8080/view/v1/room?roomId="+split[0]+"&crewId=" + split[1];
+                    // location.href = "http://ec2-52-79-236-51.ap-northeast-2.compute.amazonaws.com:8080/view/v1/room?roomId=" + split[0] + "&crewId=" + split[1];
+                    location.href="http://localhost:8080/view/v1/room?roomId="+split[0]+"&crewId=" + split[1];
                 });
         }, 2000);
     });


### PR DESCRIPTION
# 리펙토링
- 리펙토링으로 코드량을 줄이고 클린 코드를 적용하여 가독성 증가
    - **약 50% 감소 (268줄 → 137줄)**

## 리펙토링을 하며 느낀점
처음 개발을 했던 코드를 보면서 그때의 열정을 다시 느낄수 있었습니다.
어떻게든 구현을 해야했고, 결국 구현을 했지만 지금 돌아보니 부족한점이 많았습니다.

두가지를 중점으로 리펙토링을 진행하였습니다.

1. 동료 개발자가 알아볼 수 있는 클린한 코드인가?
2. 효율적으로 더 개선할 곳은 없을까?

리펙토링을 진행하며 리펙토링이란 개발자의 성장을 위한 과정이라고 느껴졌습니다.
실시간 매칭기능의 첫 리펙토링 커밋을 시작으로 지속해서 안정적이고 유연하고 클린한 코드를 작성해야겠다는
생각이 들었습니다.    


# 기능 구현

💡[**LiveMatchService**](https://github.com/ReadnThink/pocoapoco-refectoring/blob/33fa9e943236fb6e1fb73b749da21f7dfea34fee/src/main/java/teamproject/pocoapoco/service/livematch/LiveMatchService.java)  최종 리펙토링된 코드입니다.

1. 매칭 취소로직 HashMap -> RedisSet으로 변경하여 Scale Out시에도 매칭을 취소할 수 있게 변경하였습니다. 
2. 개발 처음당시 작성했던 실시간 매칭 코드를 리펙토링 하였습니다.
3. 단순 반복문, 하드코딩, 너무 많은 메소드 인자, 명확하지 않은 변수명을 리펙토링 하였습니다.
4. 배열보다는 컬렉션을 사용하여 안전한 코드를 작성하였습니다.
5. Sse로직을 SseSender를 사용해 처리하였습니다. * 기입하기
   - Sse를 전송하는 로직이 자주 사용되어 SendSse함수를 만들어
    재사용하도록 하였습니다.
6. Crew를 만드는 코드가 길어 빌더패턴을 적용하지 않고 Static 메서드를 커스텀하여 Crew를 생성하였습니다.
   - 빌더패턴을 사용하는 이유는 로직이 변경되어도 객체 생성시 필드값을 자유롭게 설정하는 것이였는데 
   랜덤매칭시 Crew를 만들때는 인자가 제한적이고, 코드가 너무 길다고 판단하여 Static 메서드를 사용했습니다.


# 주목 포인트

1. 개발 처음 만든 실시간 매칭기능을 얼마나 가독성 있고 효율적으로 리펙토링 하였는가? 

[실시간 매칭 구현하기](https://velog.io/@readnthink/%EC%8B%A4%EC%8B%9C%EA%B0%84-%EB%A7%A4%EC%B9%AD%EC%9D%84-%EC%9C%84%ED%95%9C-Redis-%EA%B3%B5%EB%B6%80) 해당 글을 통해 전체적인 흐름을 간략하게 이해하실 수 있습니다!

## 불필요한 반복문들을 제거하였습니다.

iterator 코드
```java
// 대기열에 있는 User들의 name을 넣기위해 선언 -> redis에서 삭제, user 찾을때 사용
            String[] UserListInRedis = new String[4];

            // 대기열의 User들을 확인하기 위한 iterator
            Set<String> range = redisTemplate.opsForZSet().range(sport, 0, 3);

            Iterator<String> iterator = range.iterator();
            // iterator 돌면서 user string 으로 저장 -> user 찾기 위해
            int listCnt = 0;
            while (iterator.hasNext()) {
                String next = iterator.next();
                log.info("next = {}", next);
                UserListInRedis[listCnt] = next;
                log.info("redis의 대기열 = {}",UserListInRedis[listCnt]);
                listCnt++;
            }

            // User를 찾는다 -> 모임을 만들기 위해
            User fistUser = findUserFromRedis(UserListInRedis[0]);
            User secondUser = findUserFromRedis(UserListInRedis[1]);
            User thirdUser = findUserFromRedis(UserListInRedis[2]);


            Crew savedLiveMatchCrew = makeCrew(fistUser, secondUser, thirdUser, sport);
```

변경코드
```java

final List<User> users = findUser(redisTemplate.opsForZSet().range(sport, 0, CREW_LIMIT));
Crew savedLiveMatchCrew = crewRepository.save(Crew.makeRandomMatchingCrew(users, sport, CREW_LIMIT));

```
1. Builder 패턴을 사용하다 Static 메서드를 사용해 훨씬 더 깔끔하고 가독성이 코드로 변경이 가능하였습니다.
2. 기존에는 findUserFromRedis를 사용해 User를 한명씩찾아서 받아왔습니다.
하지만 이제는 findUser에 Redis가 반환하는 Set으로 변경하였습니다. 

<br/>

## 중복되는 로직을 메서드로 변경
중복되는 로직을 메서드로 변경하여 재사용 하였습니다.

변경 전
```java
Participation firstParticipation = Participation.builder()
                .status(2)
                .user(fistUser)
                .crew(savedLiveMatchCrew)
                .title(sport + "실시간 매칭🔥")
                .build();

        Participation secParticipation = Participation.builder()
                .status(2)
                .user(secondUser)
                .crew(savedLiveMatchCrew)
                .title(sport + "실시간 매칭🔥")
                .build();

        Participation thirdParticipation = Participation.builder()
                .status(2)
                .user(thirdUser)
                .crew(savedLiveMatchCrew)
                .title(sport + "실시간 매칭🔥")
                .build();
```

변경 후
```java
        Participation firstParticipation = makeParticipation(savedLiveMatchCrew, sport, users[0]);

       private static Participation makeParticipation(final Crew savedLiveMatchCrew, final String sport, final User firstUser) {
        return Participation.builder()
                .status(2)    // todo Participation status 상태 Enum으로 가독성 높이기
                .user(firstUser)
                .crew(savedLiveMatchCrew)
                .title(sport + "실시간 매칭🔥")
                .build();
    }
```

## Enum으로 변한  하드코딩
기존에 하드코딩되어있던 Sse에 전송될 name을 Enum으로 관리하여
한군데에서 관리할 수 있도록 하였습니다.
AlarmTypeEnum을 기준으로 보신다면 코드를 리뷰하시기 편하실 것입니다. 

# 추가적으로 더 필요한 곳

* Redis에 userName을 저장하여서 불필요한 로직들이 생기고 있습니다.
Redis에 User를 저장하여서 리펙토링 할 수 있을지 검토해봐야 합니다. 
